### PR TITLE
codepen broken embed link changed 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-const SCRIPT_URL = 'https://production-assets.codepen.io/assets/embed/ei.js';
+const SCRIPT_URL = 'https://static.codepen.io/assets/embed/ei.js';
 const LOAD_STATE = {
   booting: '__booting__',
   error: '__error__',

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-const SCRIPT_URL = 'https://static.codepen.io/assets/embed/ei.js';
+const SCRIPT_URL = 'https://static.codepen.io/assets/embed/ei.js'; // new embed
 const LOAD_STATE = {
   booting: '__booting__',
   error: '__error__',


### PR DESCRIPTION
Hey ~ 

I noticed that the link was broken, and I replaced it with https://static.codepen.io/assets/embed/ei.js 

This fixed my bug on my end, and I guess, a lot of people using your package migh have the same problem, so it would be cool to update the link. 

